### PR TITLE
Make it possible to specify how many small lines should be between big lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,14 +503,15 @@ use `FlutterSliderHatchMark` class which has following properties:
 2. `bigLine`: The widget of big lines in hatch mark
 3. `smallLine`: The widget of small lines in hatch mark
 4. `linesAlignment`: the direct of lines, `right` or `left` which works as `top` or `bottom` on horizontal slider
-5. `density`: The amount of lines per percent. 1 is default. any number less or more than 1 will decrease and increase lines respectively
-6. `displayLines`: to display lines. by default is `false` for the sake of optimization
+5. `density`: The number of lines per percent. 1 is default. any number less or more than 1 will decrease and increase lines respectively
+6. `smallDensity`: The number of small lines between any two big lines. 4 is default. any number less or more than 4 will decrease and increase lines respectively.
+7. `displayLines`: to display lines. by default is `false` for the sake of optimization
 
-7. `labels`: If you want to display some label or text at certain percent in your hatch mark, you can use `labels`
-8. `labelBox`: The widget of label box, however, you can define a widget for each label and have it's own style
-9. `labelsDistanceFromTrackBar`: The distance of labels from slider. can be negative
+8. `labels`: If you want to display some label or text at certain percent in your hatch mark, you can use `labels`
+9. `labelBox`: The widget of label box, however, you can define a widget for each label and have it's own style
+10. `labelsDistanceFromTrackBar`: The distance of labels from slider. can be negative
 
-10. `disabled`: to disabled the whole hatchmark ( hide )
+11. `disabled`: to disabled the whole hatchmark ( hide )
 
 **labels alignment is center**
 

--- a/lib/another_xlider.dart
+++ b/lib/another_xlider.dart
@@ -2616,7 +2616,7 @@ class FlutterSliderHatchMark {
   FlutterSliderHatchMark(
       {this.disabled = false,
       this.density = 1,
-      this.smallDensity = 5,
+      this.smallDensity = 4,
       this.linesDistanceFromTrackBar,
       this.labelsDistanceFromTrackBar,
       this.labels,

--- a/lib/another_xlider.dart
+++ b/lib/another_xlider.dart
@@ -462,6 +462,7 @@ class _FlutterSliderState extends State<FlutterSlider>
     FlutterSliderHatchMark hatchMark = FlutterSliderHatchMark();
     hatchMark.disabled = widget.hatchMark!.disabled;
     hatchMark.density = widget.hatchMark!.density;
+    hatchMark.smallDensity = widget.hatchMark!.smallDensity;
     hatchMark.linesDistanceFromTrackBar =
         widget.hatchMark!.linesDistanceFromTrackBar ?? 0;
     hatchMark.labelsDistanceFromTrackBar =
@@ -514,7 +515,7 @@ class _FlutterSliderState extends State<FlutterSlider>
       for (int p = 0; p <= percent; p++) {
         FlutterSliderSizedBox? barLineBox = hatchMark.smallLine;
 
-        if (p % 5 - 1 == -1) {
+        if (p % (hatchMark.smallDensity + 1) == 0) {
           barLineBox = hatchMark.bigLine;
         }
 
@@ -2606,6 +2607,8 @@ class FlutterSliderHatchMark {
   List<FlutterSliderHatchMarkLabel>? labels;
   FlutterSliderSizedBox? smallLine;
   FlutterSliderSizedBox? bigLine;
+  /// How many small lines to display between two big lines
+  int smallDensity;
   FlutterSliderSizedBox? labelBox;
   FlutterSliderHatchMarkAlignment linesAlignment;
   bool? displayLines;
@@ -2613,6 +2616,7 @@ class FlutterSliderHatchMark {
   FlutterSliderHatchMark(
       {this.disabled = false,
       this.density = 1,
+      this.smallDensity = 5,
       this.linesDistanceFromTrackBar,
       this.labelsDistanceFromTrackBar,
       this.labels,
@@ -2621,7 +2625,8 @@ class FlutterSliderHatchMark {
       this.linesAlignment = FlutterSliderHatchMarkAlignment.right,
       this.labelBox,
       this.displayLines})
-      : assert(density > 0 && density <= 2);
+      : assert(density > 0 && density <= 2),
+        assert(smallDensity >= 0);
 
   @override
   String toString() {


### PR DESCRIPTION
With this PR, you can now specify a `smallDensity` that specifies how many small lines should be between two big lines.