### PR TITLE
Adjust handler placement after tap

### DIFF
--- a/lib/another_xlider.dart
+++ b/lib/another_xlider.dart
@@ -1738,6 +1738,7 @@ class _FlutterSliderState extends State<FlutterSlider>
           opacity: 0,
           child: Listener(
             onPointerUp: (_) {
+              __dragging = false;
               if (widget.selectByTap && !__dragging) {
                 tappedPositionWithPadding = _distance();
                 if (_distanceFromLeftHandler! < _distanceFromRightHandler!) {
@@ -1766,9 +1767,6 @@ class _FlutterSliderState extends State<FlutterSlider>
                 }
               }
 
-//              _adjustLeftHandlerPosition();
-//              _adjustRightHandlerPosition();
-
               _hideTooltips();
 
               _stopHandlerAnimation(
@@ -1777,8 +1775,6 @@ class _FlutterSliderState extends State<FlutterSlider>
               _stopHandlerAnimation(
                   animation: _rightHandlerScaleAnimation,
                   controller: _rightHandlerScaleAnimationController);
-
-              __dragging = false;
 
               setState(() {});
             },


### PR DESCRIPTION
This PR fixes misplacements when drag starts inside the trackbar and not on the handler or sometimes when tapping between lines. Before, I would then sometimes get the handler stuck in wrong positions between those lines until the next update. Now, it always snaps to the next line.

