### PR TITLE
Prevent exception by checking mounted state before post frame callback

### DIFF
--- a/lib/another_xlider.dart
+++ b/lib/another_xlider.dart
@@ -440,6 +440,10 @@ class _FlutterSliderState extends State<FlutterSlider>
                 curve: Curves.fastOutSlowIn));
 
     WidgetsBinding.instance!.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+
       _renderBoxInitialization();
 
       _arrangeHandlersPosition();


### PR DESCRIPTION
I got a few crashes because `_renderBoxInitialization` was called even though the widget was already disposed. Now, it will check whether the widget is still mounted before doing anything in the callback.