### PR TITLE
Update WidgetsBinding.instance to remove  flutter 3.0 warn

### DIFF
--- a/lib/another_xlider.dart
+++ b/lib/another_xlider.dart
@@ -438,7 +438,7 @@ class FlutterSliderState extends State<FlutterSlider>
                 parent: _rightTooltipAnimationController,
                 curve: Curves.fastOutSlowIn));
 
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) {
         return;
       }


### PR DESCRIPTION
Update WidgetsBinding.instance to remove "Warning: Operand of null-aware operation '?.' has type 'WidgetsBinding' which excludes null." warn for flutter 3.0