### PR TITLE
Fix tooltip autosizing

### DIFF
--- a/lib/another_xlider.dart
+++ b/lib/another_xlider.dart
@@ -1498,6 +1498,7 @@ class FlutterSliderState extends State<FlutterSlider>
           feedback: Container(),
           child: Stack(
             clipBehavior: Clip.none,
+            alignment: Alignment.center,
             children: [
               _tooltip(
                   side: 'left',
@@ -1620,6 +1621,7 @@ class FlutterSliderState extends State<FlutterSlider>
           feedback: Container(),
           child: Stack(
             clipBehavior: Clip.none,
+            alignment: Alignment.center,
             children: ([
               _tooltip(
                   side: 'right',
@@ -2049,18 +2051,12 @@ class FlutterSliderState extends State<FlutterSlider>
     switch (_tooltipData.direction) {
       case FlutterSliderTooltipDirection.top:
         top = 0;
-        left = 0;
-        right = 0;
         break;
       case FlutterSliderTooltipDirection.left:
         left = 0;
-        top = 0;
-        bottom = 0;
         break;
       case FlutterSliderTooltipDirection.right:
         right = 0;
-        top = 0;
-        bottom = 0;
         break;
       default:
         break;
@@ -2068,16 +2064,16 @@ class FlutterSliderState extends State<FlutterSlider>
 
     if (_tooltipData.positionOffset != null) {
       if (_tooltipData.positionOffset!.top != null) {
-        top = top! + _tooltipData.positionOffset!.top!;
+        top = (top ?? 0) + _tooltipData.positionOffset!.top!;
       }
       if (_tooltipData.positionOffset!.left != null) {
-        left = left! + _tooltipData.positionOffset!.left!;
+        left = (left ?? 0) + _tooltipData.positionOffset!.left!;
       }
       if (_tooltipData.positionOffset!.right != null) {
-        right = right! + _tooltipData.positionOffset!.right!;
+        right = (right ?? 0) + _tooltipData.positionOffset!.right!;
       }
       if (_tooltipData.positionOffset!.bottom != null) {
-        bottom = bottom! + _tooltipData.positionOffset!.bottom!;
+        bottom = (bottom ?? 0) + _tooltipData.positionOffset!.bottom!;
       }
     }
 


### PR DESCRIPTION
The goal of this PR is to fix an issue that the tooltip resizes itself if the font size of the text is too large.

For example in this case where the font size is 34, the more characters the text has, the smaller it gets:

![image](https://user-images.githubusercontent.com/66346043/206871611-cbf533d2-8f2a-4b2c-8d5d-f4b88b1173db.png)

So after the changes, since `right` and `left` of the `Position` widget are not being set, the `tooltipWidget` isn't constrained to the size of the stack.

![image](https://user-images.githubusercontent.com/66346043/206871708-151ff0f8-d580-404e-982e-efb29191fa5d.png)

I don't know if the original behaviour was intentional but in my opinion, if the user wants this autosizing, he/she can get it with the `custom` property.

This is my first ever contribution to open source, so if there's anything left to do in this PR just let me know!