### PR TITLE
Release/3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.1 - 29/03/2023
+- fix: selectByTap doesn't work by actual Android devices - thanks to @YasufumiMuranaka
+- kotlin_version is now '1.6.0'
+- compileSdkVersion requires version 31
+- replaced lint plugin and rules
+
 ## 3.0.0 - 21/03/2023
 Restructured the code to make it more readable, fixed documentation and flutter 3 requirements.
 Also separated classes and enums to its own files.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,9 @@
-# # Pedantic always use the latest version of the lints, with best practices from Google
-# include: package:pedantic/analysis_options.yaml
-include: package:flutter_lints/flutter.yaml
+include: package:lints/recommended.yaml
+linter:
+  rules:
+    always_declare_return_types
+    prefer_single_quotes
+    sort_child_properties_last
+    unawaited_futures
+    unsafe_html
+    use_full_hex_values_for_flutter_colors

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.0'
     repositories {
         google()
         jcenter()

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,7 +37,6 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   double _lowerValue = 50;
-  double _upperValue = 200;
 
   double _lv = 50.0;
   double _uv = 250.0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: another_xlider
 description: (Another Xlider) A material design slider and range slider, horizontal and vertical, with RTL support and lots of options and customizations for flutter
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/loonix/another_xlider
 
 environment:
@@ -13,6 +13,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  lints:
+
 
 flutter:


### PR DESCRIPTION
- fix: selectByTap doesn't work by actual Android devices - thanks to @YasufumiMuranaka
- kotlin_version is now '1.6.0'
- compileSdkVersion requires version 31
- replaced lint plugin and rules